### PR TITLE
Added options to MiniPopupTrigger

### DIFF
--- a/Loenn/triggers/miniPopup.lua
+++ b/Loenn/triggers/miniPopup.lua
@@ -15,6 +15,7 @@ trigger.placements = {
 
         mode = "OnPlayerEnter",
         onlyOnce = true,
+        removeOnLeave = true,
         flag = ""
     }
 }
@@ -36,7 +37,7 @@ trigger.fieldInformation = {
         allowXNAColors = false
     },
     mode = {
-        options = { "OnPlayerEnter", "OnFlagEnabled", "OnFlagDisabled" },
+        options = { "OnPlayerEnter", "OnFlagEnabled", "OnFlagDisabled", "WhilePlayerInside" },
         editable = false
     }
 }
@@ -49,7 +50,7 @@ trigger.fieldOrder = {
     "activeTime", "baseColor",
     "mode", "iconTexture",
     "flag", "texturePath",
-    "onlyOnce"
+    "onlyOnce", "removeOnLeave"
 }
 
 return trigger


### PR DESCRIPTION
- removeOnLeave (defaults to true) which allows the player to retrigger the popup multiple times within a single room load.
- Modes.WhilePlayerInside, which keeps the popup open while the player is inside the trigger, regardless of active time.